### PR TITLE
Added service validation

### DIFF
--- a/bashly.yml
+++ b/bashly.yml
@@ -36,6 +36,7 @@ commands:
         required: true
         help: |- 
           Service name - Requires quotations 'service'
+        validate: service
     examples:
       - uptime-kuma-service-push generate 'https://example.com/api/push/JSHs372KL8?status=up&msg=OK&ping=' 'docker'
       - uptime-kuma-service-push gen 'https://example.com/api/push/a02fD177b4?status=up&msg=OK&ping=' 'hostapd'

--- a/src/lib/validations/generate/validate_service.sh
+++ b/src/lib/validations/generate/validate_service.sh
@@ -1,0 +1,9 @@
+## Checks if the URL is valid but doing a curl before generating the script
+## src/lib/validations/url/validate_url.sh
+## This function is responsible for URL validation
+validate_service() {
+
+  ## This condition checks if the service is running, writes error message if not.
+  systemctl is-active --quiet "${1}" || echo -e "\n'${1}' is not a running service \nSee 'uptime-kuma-service-push generate --help'"
+
+}


### PR DESCRIPTION
Added service validation in a similar fashion to URL validation.

It uses `systemctl` to verify that it's active. `systemctl is-active --quiet "${1}"`

This will close #5 